### PR TITLE
Add pytest 4.2 exclusion

### DIFF
--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
-pytest>=4.0.0,<5
+pytest>=4.0.0,<4.2.0
 pytest-django>=3.4.4,<4
 black==18.9b0


### PR DESCRIPTION
For whatever reason `pytest-django` has an incompatibility with `pytest==4.2.0` (the currently latest and pulled version at time of PR) – this adds an exclusion for this version and later versions.

We should periodically check [pytest-django PyPi](https://pypi.org/project/pytest-django/) to see if versions >4.2.0 are supported.