### PR TITLE
add pyproject.toml to configure Black

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,6 @@ jobs:
         name: Run linter
         command: |
           docker-compose run --rm --no-deps server \
-            black \
-              --exclude db_layer/migrations --exclude django_conf/settings.py \
-              --check travelbear
+            black --check .
     - store_test_results:
         path: test-results

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ build-prod:
 
 fmt:
 	docker-compose -f docker-compose.dev.yml -f docker-compose.yml \
-		run --rm --no-deps server black \
-		--exclude db_layer/migrations travelbear --exclude django_conf/settings.py
+		run --rm --no-deps server black
 
 ssh:
 	docker-compose -f docker-compose.dev.yml -f docker-compose.yml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+exclude = '''
+(
+  /(
+      \.eggs
+    | \.git
+    | \.tox
+    | env
+    | venv
+    | build
+    | dist
+  )/
+  | django_conf/settings.py
+  | db_layer/migrations/
+)
+'''

--- a/travelbear/db_layer/migrations/0004_user_is_active.py
+++ b/travelbear/db_layer/migrations/0004_user_is_active.py
@@ -5,10 +5,14 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
 
-    dependencies = [("db_layer", "0003_trip_member")]
+    dependencies = [
+        ("db_layer", "0003_trip_member"),
+    ]
 
     operations = [
         migrations.AddField(
-            model_name="user", name="is_active", field=models.BooleanField(default=True)
-        )
+            model_name="user",
+            name="is_active",
+            field=models.BooleanField(default=True),
+        ),
     ]


### PR DESCRIPTION
#### This PR
- Adds `pyproject.toml` to configure exclusions for Black – this removes the need to duplicate the info across the Makefile and CircleCI .config