### PR TITLE
API Model to_dict -> serialise

### DIFF
--- a/travelbear/api_public/trips/models/location.py
+++ b/travelbear/api_public/trips/models/location.py
@@ -24,12 +24,6 @@ class Location:
             google_place_id=db_model.google_place_id,
         )
 
-    def to_dict(self):
-        dct = self._to_dict()
-        if self.coords is not None:
-            dct["coords"] = self.coords.to_tuple()
-        return dct
-
     def get_validation_errors(self):
         errors = required_fields(self, ("display_name", "coords"))
         if self.coords is None:
@@ -44,29 +38,3 @@ class Location:
         elif self.coords.lng is None:
             errors.append(get_required_field_error_message("lng"))
         return errors
-
-
-def test_from_dict():
-    data = {
-        "display_name": "some name",
-        "lat": 51.176044,
-        "lng": -0.102215,
-        "google_place_id": "goog123",
-    }
-    expected_model = Location(
-        display_name="some name",
-        coords=Coords(lat=51.176044, lng=-0.102215),
-        google_place_id="goog123",
-    )
-    assert expected_model == Location.from_dict(data)
-
-
-def test_to_dict():
-    location = Location(
-        display_name="some name", coords=Coords(51.2, -0.12), google_place_id="goog123"
-    )
-    assert {
-        "display_name": "some name",
-        "coords": (51.2, -0.12),
-        "google_place_id": "goog123",
-    } == location.to_dict()

--- a/travelbear/api_public/trips/views/get_trip_test.py
+++ b/travelbear/api_public/trips/views/get_trip_test.py
@@ -45,8 +45,6 @@ def test_return_trip_with_locations(user, trip):
 
     response = call_endpoint(user, trip.trip_id)
     assert response.status_code == 200
-    import json
-
     assert {
         "trip_id": str(trip.trip_id),
         "title": "some trip",

--- a/travelbear/api_public/trips/views/get_trip_test.py
+++ b/travelbear/api_public/trips/views/get_trip_test.py
@@ -34,7 +34,6 @@ def test_return_trip_without_locations(user, trip):
     assert {
         "trip_id": str(trip.trip_id),
         "title": "some trip",
-        "description": "",
         "locations": [],
     } == response.json()
 
@@ -48,13 +47,11 @@ def test_return_trip_with_locations(user, trip):
     assert {
         "trip_id": str(trip.trip_id),
         "title": "some trip",
-        "description": "",
         "locations": [
             {
                 "location_id": str(location.location_id),
                 "display_name": "London",
                 "coords": [51.105667, -0.120000],
-                "google_place_id": "",
             }
         ],
     } == response.json()
@@ -71,7 +68,6 @@ def test_can_get_details_if_trip_member(trip):
     assert {
         "trip_id": str(trip.trip_id),
         "title": "some trip",
-        "description": "",
         "locations": [],
     } == response.json()
 

--- a/travelbear/common/api/__init__.py
+++ b/travelbear/common/api/__init__.py
@@ -1,4 +1,4 @@
-from .api_model import api_model
+from .api_model import api_model, is_api_model
 from .validation import (
     get_required_field_error_message,
     get_type_mismatch_error_message,

--- a/travelbear/common/api/api_model_test.py
+++ b/travelbear/common/api/api_model_test.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from .api_model import API_MODEL_FLAG, api_model
+from .api_model import API_MODEL_FLAG, api_model, is_api_model
 
 
 @pytest.fixture
@@ -27,6 +27,8 @@ def test_api_model_has_expected_fields(model):
     assert "from_dict" in model.__dict__
     assert "_from_db_model" in model.__dict__
     assert "from_db_model" in model.__dict__
+    assert "_serialise" in model.__dict__
+    assert "serialise" in model.__dict__
     assert "get_validation_errors" in model.__dict__
     assert "_is_valid" in model.__dict__
     assert "is_valid" in model.__dict__
@@ -47,15 +49,15 @@ def test_post_init_called(model):
     assert mock.call_count == 3
 
 
-def test_api_model_to_dict(model):
-    assert model(1, 2).to_dict() == {"foo": 1, "bar": 2}
-    assert model(1).to_dict() == {"foo": 1}
-    assert model(bar=2).to_dict() == {"bar": 2}
-    assert model(foo=model(1, 2)).to_dict() == {"foo": {"foo": 1, "bar": 2}}
+def test_api_model_serialise(model):
+    assert model(1, 2).serialise() == {"foo": 1, "bar": 2}
+    assert model(1).serialise() == {"foo": 1}
+    assert model(bar=2).serialise() == {"bar": 2}
+    assert model(foo=model(1, 2)).serialise() == {"foo": {"foo": 1, "bar": 2}}
 
 
 def test_api_model_from_dict(model):
-    assert model.from_dict({"foo": 1, "bar": 2}).to_dict() == {"foo": 1, "bar": 2}
+    assert model.from_dict({"foo": 1, "bar": 2}) == model(foo=1, bar=2)
 
 
 def test_is_valid(model):
@@ -73,3 +75,13 @@ def test_is_valid(model):
     assert model.from_db_model(model(5, 5)).validation_errors == [
         "foo and bar cannot sum to 10"
     ]
+
+
+def test_is_api_model(model):
+    assert is_api_model(model)
+
+    class Bar:
+        pass
+
+    assert is_api_model(Bar) is False
+    assert is_api_model(None) is False

--- a/travelbear/common/models/geo.py
+++ b/travelbear/common/models/geo.py
@@ -18,6 +18,9 @@ class Coords:
     def to_tuple(self):
         return self.lat, self.lng
 
+    def serialise(self):
+        return self.to_tuple()
+
 
 def test_initialisation():
     assert Coords("90.1", "180.0") == Coords(90.1, 180)

--- a/travelbear/common/response/serialize.py
+++ b/travelbear/common/response/serialize.py
@@ -1,8 +1,10 @@
 from django.core.serializers.json import DjangoJSONEncoder
 
+from common.api import is_api_model
+
 
 class APIModelJSONSerializer(DjangoJSONEncoder):
     def default(self, o):
-        if hasattr(o, "__api_model__"):
-            return o.to_dict()
+        if is_api_model(o.__class__):
+            return o.serialise()
         return super().default(o)


### PR DESCRIPTION
Not all api_models are best represented as a dict (e.g. Coords might be serialised as a tuple) this PR renames `to_dict` to convey this

#### This PR
- Updates `to_dict` to `serialise`
- Updates serialise to omit `""` values